### PR TITLE
Avoid connection error because one endpoint is not reachable.

### DIFF
--- a/puka/exceptions.py
+++ b/puka/exceptions.py
@@ -3,7 +3,7 @@ from . import spec_exceptions
 
 class ConnectionBroken(socket.error): pass
 class UnsupportedProtocol(socket.error): pass
-
+class ConnectionError(socket.error): pass
 
 def exception_from_frame(result):
     reply_code = result.get('reply_code', 0)


### PR DESCRIPTION
For example, if getaddrinfo resolve to 5 different ipv4 endpoints and one ipv6, all of them must be tested before giving up with a connection error.
