### PR TITLE
Improved encode/decode field values

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -303,8 +303,8 @@ class TestBasic(base.TestCase):
             "app_id": 'j',
             "cluster_id": 'k',
             "custom": 'l',
-            "blah2": [True, 1, -1, 4611686018427387904L,
-                      -4611686018427387904L, [1,2,3,4, {"a":"b", "c":[]}]],
+            "blah2": [True, 1, -1, 64000L, None, float(12e10),
+                      -64000L, [1,2,3,4, {"a":"b", "c":[]}]],
             }
 
         t = client.basic_publish(exchange='', routing_key=self.name,


### PR DESCRIPTION
Ok, here is an updated pull for the encode/decode stuff.  This was done against the 0-9-1 errata as well as looking in Rabbit's internals.  There is a great deal of divergence between what Rabbit does and what the 0-9-1 spec says.  Also, there is some divergence between the 0-9-1 errata and Rabbit's actual implementation.

Here are the exact changes:

For encode:
- added 'd' field, double precision float
- added conversion of longs > 64 bits into long strings
- added 'V' no-field

Other notes on encode:
- I didn't add 'f', single precision floats can live inside doubles
- I let other small integers live inside 'I' 32 bit integers (b and s)
- Rabbit does not support unsigned integers at all, except for 'b' 8 bit, but this appears to be a bug in their code as that usage does not match their 0-9-1 errata and there are no other instances of unsigned types.
- I didn't add 'x' since I wasn't sure what data type to start with there

For decode:
- Added 'b', unsigned 8 bit integer (NB: Rabbit's code is different from the errata here, there are no unsigned integers supported otherwise)
- Added 'f' single precision IEE float
- Added 'd' double precision IEEE float (turned out to be the same as xdr)
- Added 's' signed 16 bit integer
- Added 'x' binary string
- Added 'V' no-field
