### PR TITLE
add ability to set client connection properties

### DIFF
--- a/docs/puka.rst
+++ b/docs/puka.rst
@@ -22,13 +22,14 @@ For more information see:
 
 The :mod:`puka` module defines a single class:
 
-.. class:: Client(amqp_url='amqp:///', pubacks=None)
+.. class:: Client(amqp_url='amqp:///', pubacks=None, client_properties=None)
 
    Consturctor for :class:`Client` class. `amqp_url` is an url-like
    address of the RabbitMQ server. Default points to
    `amqp://guest:guest@localhost:5672/`. `pubacks` tells if the client
    should take advantage of the publiser-acks feature on the server -
-   autodetect by default.
+   autodetect by default.  `client_properties` is a dict of properties
+   to add to the connection properties sent to the server.
 
 Exceptions
 ----------

--- a/puka/connection.py
+++ b/puka/connection.py
@@ -21,7 +21,7 @@ log = logging.getLogger('puka')
 class Connection(object):
     frame_max = 131072
 
-    def __init__(self, amqp_url='amqp:///', pubacks=None):
+    def __init__(self, amqp_url='amqp:///', pubacks=None, client_properties=None):
         self.pubacks = pubacks
 
         self.channels = channel.ChannelCollection()
@@ -29,6 +29,8 @@ class Connection(object):
 
         (self.username, self.password, self.vhost, self.host, self.port) = \
             parse_amqp_url(str(amqp_url))
+
+        self.client_properties = client_properties
 
     def _init_buffers(self):
         self.recv_buf = simplebuffer.SimpleBuffer()

--- a/puka/machine.py
+++ b/puka/machine.py
@@ -30,9 +30,13 @@ def _connection_start(t, result):
     ccapa = {}
     if scapa.get('consumer_cancel_notify'):
         ccapa['consumer_cancel_notify'] = True
-    frames = spec.encode_connection_start_ok({'product': 'Puka',
-                                              'capabilities': ccapa},
-                                             'PLAIN', response, 'en_US')
+
+    properties = {'product': 'Puka', 'capabilities': ccapa}
+    if t.conn.client_properties is not None:
+        properties.update(t.conn.client_properties)
+
+    frames = spec.encode_connection_start_ok(properties,
+                                    'PLAIN', response, 'en_US')
     t.register(spec.METHOD_CONNECTION_TUNE, _connection_tune)
     t.send_frames(frames)
     t.x_cached_result = result

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -26,6 +26,27 @@ class TestBasic(base.TestCase):
         promise = client.queue_delete(queue=self.name)
         client.wait(promise)
 
+    def test_simple_roundtrip_with_connection_properties(self):
+        props = { 'puka_test': 'blah', 'random_prop': 1234 }
+
+        client = puka.Client(self.amqp_url, client_properties=props)
+        promise = client.connect()
+        client.wait(promise)
+
+        promise = client.queue_declare(queue=self.name)
+        client.wait(promise)
+
+        promise = client.basic_publish(exchange='', routing_key=self.name,
+                                       body=self.msg)
+        client.wait(promise)
+
+        consume_promise = client.basic_consume(queue=self.name, no_ack=True)
+        result = client.wait(consume_promise)
+        self.assertEqual(result['body'], self.msg)
+
+        promise = client.queue_delete(queue=self.name)
+        client.wait(promise)
+
 
     def test_purge(self):
         client = puka.Client(self.amqp_url)


### PR DESCRIPTION
A clean pull request for the client properties change.

I added a very simple test, but I don't know of any easy way to read back the connection properties without hitting the HTTP server on the rabbit box (and assuming the management plugin is running there too).  If you can think of anything better, let me know.
