### PR TITLE
make on_write handle shutdown connections and an empty buffer

### DIFF
--- a/puka/connection.py
+++ b/puka/connection.py
@@ -186,6 +186,8 @@ class Connection(object):
         return bool(self.send_buf)
 
     def on_write(self):
+        if not self.send_buf:  # already shutdown or empty buffer?
+            return
         try:
             # On windows socket.send blows up if the buffer is too large.
             r = self.sd.send(self.send_buf.read(128*1024))


### PR DESCRIPTION
Connection._shutdown sets the sd and send_buf attributes to
None. on_write may be called after _shutdown was called.  We return
early now in on_write if send_buf is None or if it is empty.

see issue #23: https://github.com/majek/puka/issues/23
