### PR TITLE
Allow caller to specify consumer_tag

### DIFF
--- a/puka/machine.py
+++ b/puka/machine.py
@@ -246,13 +246,15 @@ def basic_consume_multi(conn, queues, prefetch_count=0, no_ack=False):
             queue = item
             no_local = exclusive = False
             arguments = {}
+            consumer_tag = ''
         else:
             queue = item['queue']
             no_local = item.get('no_local', False)
             exclusive = item.get('exclusive', False)
             arguments = item.get('arguments', {})
+            consumer_tag = item.get('consumer_tag', '')
         t.x_consumes.append( (queue, spec.encode_basic_consume(
-                    queue, '', no_local, no_ack, exclusive, arguments)) )
+                    queue, consumer_tag, no_local, no_ack, exclusive, arguments)) )
     t.x_no_ack = no_ack
     t.x_consumer_tag = {}
     t.register(spec.METHOD_BASIC_DELIVER, _bcm_basic_deliver)


### PR DESCRIPTION
This change allows the caller of the library to specify the "consumer_tag" on consume set-up, which then results in that same consumer tag being appear attached to messages received.

Needed if you're listening to > 1 routing key and you need to know which key caused you to receive a message.
