### PR TITLE
ignore EWOULDBLOCK and ENOBUFS when sending

### DIFF
--- a/puka/connection.py
+++ b/puka/connection.py
@@ -16,6 +16,7 @@ from . import promise
 
 log = logging.getLogger('puka')
 
+_ignore_errno_send = (errno.EWOULDBLOCK, errno.ENOBUFS)
 
 
 class Connection(object):
@@ -195,7 +196,7 @@ class Connection(object):
             # On windows socket.send blows up if the buffer is too large.
             r = self.sd.send(self.send_buf.read(128*1024))
         except socket.error, e:
-            if e.errno == errno.EAGAIN:
+            if e.errno in _ignore_errno_send:
                 return
             else:
                 raise


### PR DESCRIPTION
this is what the twisted framework also ignores, we trust them here.
the previously used EAGAIN is the same as EWOULDBLOCK on linux.

fixes issue #40
