### PR TITLE
remove utf-8 decoder on inbound message bodies

### DIFF
--- a/puka/channel.py
+++ b/puka/channel.py
@@ -92,7 +92,7 @@ class Channel(object):
             result = self.method_frame
             props = self.props
 
-            result['body'] = compat.as_str(compat.join_as_bytes(self.body_chunks))
+            result['body'] = compat.join_as_bytes(self.body_chunks)
             result['headers'] = props.get('headers', {})
             # Aint need a reference loop.
             if 'headers' in props:


### PR DESCRIPTION
Puka is assuming inbound message bodies are a utf-8 encoded byte stream. Although its common for message bodies to be utf-8 encoded byte streams, they are still just byte streams, and it is wrong to assume they are utf-8 encoded.  This assumption prevents Puka from handling a message whose body is binary.

This patch removes that assumption. The application using Puka will need to handle the byte stream and decode it according to its use case.